### PR TITLE
fix(storage): physical file not deleted when removing anime from storage

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aniseek-api"
-version = "2.0.10"
+version = "2.0.11"
 description = "REST API for anime streaming and scraping management"
 readme = "README.md"
 requires-python = ">=3.10.14"

--- a/backend/src/packages/episodes/service.py
+++ b/backend/src/packages/episodes/service.py
@@ -240,5 +240,9 @@ async def delete_anime_storage_controller(anime_id: str, user_id: str) -> str:
     if anime_folder.exists() and is_folder_empty(anime_folder):
         shutil.rmtree(anime_folder)
         logger.debug(f"Deleted folder: {anime_folder}")
+        root_folder = anime_folder.parent
+        if root_folder.exists() and is_folder_empty(root_folder):
+            shutil.rmtree(root_folder)
+            logger.debug(f"Deleted folder: {root_folder}")
 
     return "Anime storage deleted successfully"

--- a/backend/src/packages/episodes/service.py
+++ b/backend/src/packages/episodes/service.py
@@ -225,10 +225,8 @@ async def delete_anime_storage_controller(anime_id: str, user_id: str) -> str:
     franchise_id = anime["franchise_id"]
     parsed_season = str(anime["season"]).zfill(2)
 
-    if franchise_id:
-        anime_folder = ANIMES_FOLDER / franchise_id / f"Season {parsed_season}"
-    else:
-        anime_folder = ANIMES_FOLDER / anime_id
+    folder_root = franchise_id if franchise_id else anime_id
+    anime_folder = ANIMES_FOLDER / folder_root / f"Season {parsed_season}"
 
     for episode in anime["episodes"]:
         parsed_ep_number = str(episode["ep_number"]).zfill(2)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "aniseek-api"
-version = "2.0.10"
+version = "2.0.11"
 source = { virtual = "." }
 dependencies = [
     { name = "ani-scrapy" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "private": true,
   "type": "module",
   "imports": {

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aniseek-worker"
-version = "2.0.10"
+version = "2.0.11"
 description = "Background worker for anime scraping tasks"
 readme = "README.md"
 requires-python = ">=3.10.14"

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "aniseek-worker"
-version = "2.0.10"
+version = "2.0.11"
 source = { virtual = "." }
 dependencies = [
     { name = "ani-scrapy" },


### PR DESCRIPTION
## Summary

- Fixed path mismatch between worker (save) and backend service (delete): the `Season XX` subdirectory was missing in the delete path for animes without a `franchise_id`, causing `file_path.exists()` to always return `False`
- Added cascade empty-directory cleanup: after deleting episode files, removes the `Season XX` folder if empty, then removes the parent anime/franchise folder if also empty

## Root cause

The worker always saves to `{ANIMES_FOLDER}/{folder_root}/Season {season}/`, but the delete service used `{ANIMES_FOLDER}/{anime_id}/` (no `Season` subdirectory) when `franchise_id` was null — so no file was ever found or deleted.

## Test plan

- [ ] Delete an anime with no `franchise_id` — verify `.mp4` files are removed from disk
- [ ] Delete an anime with a `franchise_id` — verify files are removed from the franchise subfolder
- [ ] Delete the last season of an anime — verify `Season XX/` folder is removed
- [ ] Delete the only season of an anime — verify the root anime/franchise folder is also removed
- [ ] Confirm DB records are still reset correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)