### PR TITLE
fix(frontend): prefer runtime config over build-time define for AUTH_ENABLED

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aniseek-api"
-version = "2.0.12"
+version = "2.0.13"
 description = "REST API for anime streaming and scraping management"
 readme = "README.md"
 requires-python = ">=3.10.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "aniseek-api"
-version = "2.0.12"
+version = "2.0.13"
 source = { virtual = "." }
 dependencies = [
     { name = "ani-scrapy" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "type": "module",
   "imports": {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,12 +1,18 @@
-export const config: AppConfig = window.__APP_CONFIG__;
+export const config: AppConfig | undefined = window.__APP_CONFIG__;
 
 declare const __API_URL__: string | undefined;
 declare const __AUTH_ENABLED__: string | undefined;
 
 export const apiUrl: string =
-	typeof __API_URL__ !== "undefined" ? __API_URL__ : config.API_URL;
+	config?.API_URL !== undefined
+		? config.API_URL
+		: typeof __API_URL__ !== "undefined"
+			? __API_URL__
+			: "";
 
 export const isAuthEnabled: boolean =
-	typeof __AUTH_ENABLED__ !== "undefined"
-		? __AUTH_ENABLED__ === "true"
-		: config.AUTH_ENABLED === true || config.AUTH_ENABLED === "true";
+	config?.AUTH_ENABLED !== undefined
+		? config.AUTH_ENABLED === true || config.AUTH_ENABLED === "true"
+		: typeof __AUTH_ENABLED__ !== "undefined"
+			? __AUTH_ENABLED__ === "true"
+			: false;

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aniseek-worker"
-version = "2.0.12"
+version = "2.0.13"
 description = "Background worker for anime scraping tasks"
 readme = "README.md"
 requires-python = ">=3.10.14"

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "aniseek-worker"
-version = "2.0.12"
+version = "2.0.13"
 source = { virtual = "." }
 dependencies = [
     { name = "ani-scrapy" },


### PR DESCRIPTION
## Summary

- `isAuthEnabled` y `apiUrl` ahora priorizan `window.__APP_CONFIG__` (generado en runtime por `entrypoint.sh`) sobre las constantes horneadas en el build
- Antes, si el build se compilaba con `AUTH_ENABLED=false`, el valor quedaba fijo aunque el `docker-compose` lo definiera como `true` en runtime
- Bump a v2.0.13

## Root cause

En `config.ts` la lógica evaluaba primero `typeof __AUTH_ENABLED__ !== "undefined"`, que siempre es `true` cuando Vite inyecta el define en build-time — ignorando completamente el `config.js` del runtime.

## Test plan

- [ ] Desplegar con `AUTH_ENABLED=true` en el compose y verificar que el login aparece al hacer logout
- [ ] Desplegar con `AUTH_ENABLED=false` y verificar que auto-loguea sin pedir credenciales
- [ ] Verificar que en dev local (`vite dev`) sigue funcionando el fallback al build-time define