### PR TITLE
fix(nginx): proxy /api to backend container for URL-independent routing

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aniseek-api"
-version = "2.0.13"
+version = "2.0.14"
 description = "REST API for anime streaming and scraping management"
 readme = "README.md"
 requires-python = ">=3.10.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "aniseek-api"
-version = "2.0.13"
+version = "2.0.14"
 source = { virtual = "." }
 dependencies = [
     { name = "ani-scrapy" },

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -10,7 +10,6 @@ services:
     ports:
       - 3000:80
     environment:
-      - API_URL=${API_URL}
       - AUTH_ENABLED=false
 
   aniseek-api:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,6 @@ services:
     ports:
       - "3000:80"
     environment:
-      - API_URL=${API_URL}
       - AUTH_ENABLED=${AUTH_ENABLED}
 
   aniseek-api:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,6 +13,18 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    location /api/ {
+        proxy_pass http://aniseek-api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "private": true,
   "type": "module",
   "imports": {

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aniseek-worker"
-version = "2.0.13"
+version = "2.0.14"
 description = "Background worker for anime scraping tasks"
 readme = "README.md"
 requires-python = ">=3.10.14"

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "aniseek-worker"
-version = "2.0.13"
+version = "2.0.14"
 source = { virtual = "." }
 dependencies = [
     { name = "ani-scrapy" },


### PR DESCRIPTION
## Summary

- Add nginx `proxy_pass` block to route `/api/` requests to the `aniseek-api` container by Docker service name, eliminating the need for a hardcoded `API_URL`
- Configure nginx for SSE and file downloads: `proxy_buffering off`, `proxy_http_version 1.1`, `proxy_read_timeout 3600s`
- Remove `API_URL` environment variable from `compose.yaml` and `compose.dev.yaml` (deployment is always done together under a single compose)
- Bump all services to v2.0.14

## Test plan

- [ ] Deploy with `docker compose up` and verify the frontend loads
- [ ] Verify API requests reach the backend (check Network tab — calls to `/api/*` should return data)
- [ ] Verify SSE download progress updates work on the downloads page
- [ ] Verify episode file downloads trigger correctly
- [ ] Access the app from a non-localhost URL and confirm all requests still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)