### PR TITLE
ci: bump github actions to node 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
         uses: docker/build-push-action@v7
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           provenance: false
           sbom: false
@@ -139,6 +140,8 @@ jobs:
       - name: Push stamped image
         if: steps.decide.outputs.action == 'stamp'
         uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: Dockerfile.promote

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       previous: ${{ steps.compare.outputs.previous }}
       should-release: ${{ steps.compare.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -69,14 +69,14 @@ jobs:
           - image: migrate
             dir: dbmate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build image
         if: steps.decide.outputs.action == 'build'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         with:
@@ -138,7 +138,7 @@ jobs:
       # necesita emulación QEMU para arm64 pese a construir multi-arch.
       - name: Push stamped image
         if: steps.decide.outputs.action == 'stamp'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.promote
@@ -150,10 +150,10 @@ jobs:
     needs: [detect, publish]
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.detect.outputs.version }}
           generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Recurrir a `Grep` o `Read` cuando codegraph no aplica: archivos que no son códi
 
 - No hacer commit automáticamente después de cada cambio. Solo hacer commit cuando el usuario lo pida explícitamente.
 - No agregar coautor (`Co-Authored-By`) a los commits.
+- Los mensajes de commit siguen conventional commits en inglés, con descripción corta (sin cuerpo extenso salvo que se pida explícitamente).
 
 ## OpenSpec
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -10,7 +10,7 @@ services:
     ports:
       - 3000:80
     environment:
-      - AUTH_ENABLED=false
+      - AUTH_ENABLED=False
 
   aniseek-api:
     build:


### PR DESCRIPTION
## Resumen

Actualiza las GitHub Actions usadas en `release.yml` a las versiones mayores que corren nativamente en Node 24, eliminando el warning de deprecación de Node 20 en las corridas del pipeline.

| Action | Antes | Ahora |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `softprops/action-gh-release` | v2 | v3 |

Sin cambios de inputs/outputs que afecten los steps existentes (`provenance`, `sbom`, `cache-from`/`cache-to`, etc. se mantienen).

Incluye además otros cambios sueltos que ya estaban en el working directory antes de esta tarea:
- `DOCKER_BUILD_RECORD_UPLOAD: false` en los steps de `docker/build-push-action`.
- Nota de convención de mensajes de commit en `CLAUDE.md`.
- Ajuste de `AUTH_ENABLED` en `compose.dev.yaml`.

## Commits

1. `ci: bump github actions to node 24-compatible versions`
2. `chore: misc workflow, docs and dev-compose tweaks`