### PR TITLE
refactor(animes): decouple scraping from persistence in update_anime_info

### DIFF
--- a/backend/src/packages/animes/service.py
+++ b/backend/src/packages/animes/service.py
@@ -54,30 +54,43 @@ def build_anime_response(anime_db: dict) -> dict:
     return cast_anime_info(get_anime_info_to_dict(anime_db), anime_db["saved_info"])
 
 
-async def add_new_anime(base_url: str, anime_id: str) -> None:
-    logger.debug(f"Adding anime to database: {anime_id}")
-    anime_info = await scrape_anime_info(anime_id, include_episodes=True)
+def _anime_fields_from_info(anime_info, current_time: datetime) -> dict:
     week_day = (
         anime_info.next_episode_date.strftime("%A")
         if anime_info.next_episode_date
         else None
     )
+    return {
+        "title": anime_info.title,
+        "description": anime_info.description,
+        "poster": anime_info.poster,
+        "type": anime_info.type.value,
+        "is_finished": anime_info.is_finished,
+        "week_day": week_day,
+        "last_scraped_at": current_time,
+    }
+
+
+def _episode_values(episodes, anime_id: str, base_url: str) -> list[dict]:
+    return [
+        {
+            "anime_id": anime_id,
+            "ep_number": ep.episode_number,
+            "preview": ep.image_preview,
+            "url": f"{base_url}/{ep.episode_number}",
+        }
+        for ep in episodes
+    ]
+
+
+async def add_new_anime(base_url: str, anime_id: str) -> None:
+    logger.debug(f"Adding anime to database: {anime_id}")
+    anime_info = await scrape_anime_info(anime_id, include_episodes=True)
     current_time = datetime.now(timezone.utc)
+    anime_fields = _anime_fields_from_info(anime_info, current_time)
 
     async with engine.begin() as conn:
-        await repository.upsert_scraped_anime(
-            conn,
-            {
-                "id": anime_info.id,
-                "title": anime_info.title,
-                "description": anime_info.description,
-                "poster": anime_info.poster,
-                "type": anime_info.type.value,
-                "is_finished": anime_info.is_finished,
-                "week_day": week_day,
-                "last_scraped_at": current_time,
-            },
-        )
+        await repository.upsert_scraped_anime(conn, {"id": anime_info.id, **anime_fields})
         logger.debug(f"Upserted anime: {anime_info.id}")
 
         await repository.insert_genres(conn, anime_info.id, list(anime_info.genres))
@@ -90,43 +103,29 @@ async def add_new_anime(base_url: str, anime_id: str) -> None:
             )
         logger.debug("Inserted related animes")
 
-        episode_values = [
-            {
-                "anime_id": anime_info.id,
-                "ep_number": ep.episode_number,
-                "preview": ep.image_preview,
-                "url": f"{base_url}/{ep.episode_number}",
-            }
-            for ep in anime_info.episodes
-        ]
+        episode_values = _episode_values(anime_info.episodes, anime_info.id, base_url)
         await repository.insert_episodes(conn, episode_values)
         logger.debug("Inserted episodes")
 
 
 async def update_anime_info(base_url: str, anime_id: str) -> None:
+    # Fase de recoleccion: todo el I/O externo (scraping, espera de rate limit)
+    # ocurre antes de abrir la transaccion de escritura, para no retener una
+    # conexion del pool mientras se espera una respuesta de red.
     current_time = datetime.now(timezone.utc)
     anime_info = await scrape_anime_info(anime_id, include_episodes=False)
+    anime_fields = _anime_fields_from_info(anime_info, current_time)
 
-    week_day = (
-        anime_info.next_episode_date.strftime("%A")
-        if anime_info.next_episode_date
-        else None
-    )
+    async with engine.connect() as conn:
+        last_ep_number = await repository.get_max_episode_number(conn, anime_id)
 
+    await asyncio.sleep(1.5)
+    new_episodes = await scrape_new_episodes(anime_id, last_ep_number)
+    new_episode_values = _episode_values(new_episodes, anime_id, base_url)
+
+    # Fase de escritura: una unica transaccion corta, sin I/O externo dentro.
     async with engine.begin() as conn:
-        await repository.update_anime_fields(
-            conn,
-            anime_id,
-            {
-                "title": anime_info.title,
-                "description": anime_info.description,
-                "poster": anime_info.poster,
-                "type": anime_info.type.value,
-                "is_finished": anime_info.is_finished,
-                "week_day": week_day,
-                "last_scraped_at": current_time,
-            },
-        )
+        await repository.update_anime_fields(conn, anime_id, anime_fields)
 
         for related in anime_info.related_info:
             await repository.insert_dummy_anime(conn, related.id, related.title)
@@ -134,23 +133,7 @@ async def update_anime_info(base_url: str, anime_id: str) -> None:
                 conn, anime_info.id, related.id, related_types_id[related.type.value]
             )
 
-        await asyncio.sleep(1.5)
-        last_ep_number = await repository.get_max_episode_number(conn, anime_id)
-        new_episodes = await scrape_new_episodes(anime_id, last_ep_number)
-
-        await repository.insert_new_episodes(
-            conn,
-            anime_id,
-            [
-                {
-                    "anime_id": anime_id,
-                    "ep_number": ep.episode_number,
-                    "preview": ep.image_preview,
-                    "url": f"{base_url}/{ep.episode_number}",
-                }
-                for ep in new_episodes
-            ],
-        )
+        await repository.insert_new_episodes(conn, anime_id, new_episode_values)
 
 
 async def update_anime_controller(anime_id: str, user_id: str) -> dict:

--- a/backend/tests/test_animes_atomicity.py
+++ b/backend/tests/test_animes_atomicity.py
@@ -5,6 +5,11 @@ the transaction makes after its first write, so it fails without depending on
 a schema constraint. Design D6 also notes the scraping calls have to be
 substituted regardless of where the failure lands, so no test ever reaches the
 network.
+
+decouple-anime-scrape-persist: update_anime_info now runs both scrapes (and
+the rate-limit sleep between them) before opening its write transaction, so
+scrape_new_episodes and asyncio.sleep must be substituted too — they're no
+longer shielded by a failure injected inside the transaction.
 """
 
 from datetime import datetime, timezone
@@ -31,11 +36,15 @@ def _fake_anime_info(anime_id: str, **overrides) -> AnimeInfo:
     return AnimeInfo(**fields)
 
 
-def _fake_scrape(anime_info: AnimeInfo):
+def _fake_scrape(result):
     async def _scrape(*args, **kwargs):
-        return anime_info
+        return result
 
     return _scrape
+
+
+async def _no_sleep(*args, **kwargs) -> None:
+    pass
 
 
 async def _boom(*args, **kwargs):
@@ -62,6 +71,8 @@ async def test_add_new_anime_leaves_no_trace_on_mid_transaction_failure(
 async def test_update_anime_info_keeps_previous_fields_on_mid_transaction_failure(
     raw_conn, monkeypatch
 ):
+    import asyncio
+
     from packages.animes import repository, service
 
     anime_id = "atomic-update-anime"
@@ -88,6 +99,11 @@ async def test_update_anime_info_keeps_previous_fields_on_mid_transaction_failur
         related_info=[RelatedInfo(id="related-anime", title="Related", type=RelatedType.SEQUEL)],
     )
     monkeypatch.setattr(service, "scrape_anime_info", _fake_scrape(fake_info))
+    # Both scrapes and the rate-limit sleep now run before the write
+    # transaction opens, so they must be substituted regardless of where the
+    # failure lands inside that transaction.
+    monkeypatch.setattr(service, "scrape_new_episodes", _fake_scrape([]))
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
     # First write is update_anime_fields; interrupt right after it, in the
     # related_info loop.
     monkeypatch.setattr(repository, "insert_dummy_anime", _boom)

--- a/backend/tests/test_animes_scrape_persist_order.py
+++ b/backend/tests/test_animes_scrape_persist_order.py
@@ -1,0 +1,123 @@
+"""decouple-anime-scrape-persist: covers the two things that change in
+packages/animes/service.py:
+
+- The pure mapping helpers (_anime_fields_from_info, _episode_values)
+  extracted out of add_new_anime/update_anime_info — no I/O, so no database
+  or scraping fixtures needed.
+- That update_anime_info actually performs both scrapes (and the rate-limit
+  sleep between them) before it opens its write transaction, not just after
+  the reorder "looks right" in the diff.
+"""
+
+from datetime import datetime, timezone
+
+from ani_scrapy.core import AnimeType, EpisodeInfo
+from factories import create_anime
+
+from test_animes_atomicity import _fake_anime_info, _no_sleep
+
+
+def test_anime_fields_from_info_maps_columns_without_week_day():
+    from packages.animes.service import _anime_fields_from_info
+
+    info = _fake_anime_info("anime-1", type=AnimeType.TV, next_episode_date=None)
+    current_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    fields = _anime_fields_from_info(info, current_time)
+
+    assert fields == {
+        "title": info.title,
+        "description": info.description,
+        "poster": info.poster,
+        "type": "TV",
+        "is_finished": info.is_finished,
+        "week_day": None,
+        "last_scraped_at": current_time,
+    }
+
+
+def test_anime_fields_from_info_derives_week_day_from_next_episode_date():
+    from packages.animes.service import _anime_fields_from_info
+
+    # 2026-01-05 is a Monday.
+    next_episode = datetime(2026, 1, 5, tzinfo=timezone.utc)
+    info = _fake_anime_info("anime-1", next_episode_date=next_episode)
+
+    fields = _anime_fields_from_info(info, datetime.now(timezone.utc))
+
+    assert fields["week_day"] == "Monday"
+
+
+def test_episode_values_maps_episodes_to_insertable_rows():
+    from packages.animes.service import _episode_values
+
+    episodes = [
+        EpisodeInfo(episode_number=1, anime_id="anime-1", image_preview="preview-1.png"),
+        EpisodeInfo(episode_number=2, anime_id="anime-1", image_preview=None),
+    ]
+
+    values = _episode_values(episodes, "anime-1", "https://example.test/media/anime-1")
+
+    assert values == [
+        {
+            "anime_id": "anime-1",
+            "ep_number": 1,
+            "preview": "preview-1.png",
+            "url": "https://example.test/media/anime-1/1",
+        },
+        {
+            "anime_id": "anime-1",
+            "ep_number": 2,
+            "preview": None,
+            "url": "https://example.test/media/anime-1/2",
+        },
+    ]
+
+
+def test_episode_values_of_empty_list_is_empty():
+    from packages.animes.service import _episode_values
+
+    assert _episode_values([], "anime-1", "https://example.test") == []
+
+
+async def test_update_anime_info_scrapes_before_opening_write_transaction(
+    raw_conn, monkeypatch
+):
+    import asyncio
+
+    from packages.animes import repository, service
+
+    anime_id = "order-update-anime"
+    await create_anime(raw_conn, anime_id=anime_id, title="Previous Title")
+
+    call_order = []
+
+    def _tracking_scrape(name, result):
+        async def _scrape(*args, **kwargs):
+            call_order.append(name)
+            return result
+
+        return _scrape
+
+    fake_info = _fake_anime_info(anime_id, related_info=[])
+    monkeypatch.setattr(
+        service, "scrape_anime_info", _tracking_scrape("scrape_anime_info", fake_info)
+    )
+    monkeypatch.setattr(
+        service, "scrape_new_episodes", _tracking_scrape("scrape_new_episodes", [])
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    original_update_anime_fields = repository.update_anime_fields
+
+    async def _tracking_update_anime_fields(conn, anime_id, values):
+        # The first write inside update_anime_info's transaction: reaching it
+        # proves the write transaction has opened by this point.
+        call_order.append("update_anime_fields")
+        return await original_update_anime_fields(conn, anime_id, values)
+
+    monkeypatch.setattr(repository, "update_anime_fields", _tracking_update_anime_fields)
+
+    await service.update_anime_info("https://example.test", anime_id)
+
+    assert call_order == ["scrape_anime_info", "scrape_new_episodes", "update_anime_fields"]

--- a/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/design.md
+++ b/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`update_anime_info` (`backend/src/packages/animes/service.py:106-153`) hoy hace, dentro de un único `async with engine.begin() as conn:`:
+
+1. `update_anime_fields` (escritura)
+2. `insert_dummy_anime` / `insert_anime_relation` por cada relacionado (escritura)
+3. `await asyncio.sleep(1.5)` (pausa deliberada por rate limit del sitio scrapeado, sin tocar la base)
+4. `get_max_episode_number` (lectura)
+5. `scrape_new_episodes` (HTTP externo hacia AnimeAV1)
+6. `insert_new_episodes` (escritura)
+
+Los pasos 3-5 no usan la conexión de Postgres para nada esencial —la lectura del paso 4 podría hacerse fuera de la transacción de escritura, ya que no depende de las escrituras 1-2 (tocan `animes`/`anime_relations`, no `episodes`)— pero mantienen la transacción abierta mientras dura una espera fija de 1.5s más una petición HTTP externa no determinística. Bajo carga concurrente esto retiene conexiones del pool más tiempo del necesario.
+
+`add_new_anime` (línea 57-103) no tiene este problema: scrapea (`scrape_anime_info`, línea 59) antes de abrir `engine.begin()` (línea 67). Sirve como referencia del orden correcto.
+
+El capability `database-access` ya exige atomicidad para operaciones de varias escrituras (`openspec/specs/database-access/spec.md`, requirement "Una operación de varias escrituras es atómica"). Ese requirement se preserva; este cambio agrega uno nuevo sobre el alcance de la conexión frente a I/O externo.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Que ninguna transacción de escritura en `update_anime_info` permanezca abierta durante scraping HTTP o esperas artificiales.
+- Preservar la atomicidad actual: todas las escrituras de `update_anime_info` siguen confirmándose juntas o ninguna.
+- Extraer el mapeo `AnimeInfo` (scraper) → `dict` de columnas a funciones puras, testeables sin mockear red ni base de datos.
+
+**Non-Goals:**
+- Tocar `add_new_anime`: ya scrapea antes de abrir la transacción; no tiene el problema de retención de conexión. Fuera de alcance según lo acordado con el usuario.
+- Modificar `scraper.py` o `repository.py`: el cambio es de orquestación en `service.py`, no de las funciones de scraping ni de acceso a datos en sí.
+- Cambiar la semántica de reintentos, rate-limiting o el propósito del `sleep(1.5)` frente al sitio scrapeado — solo se reubica.
+- Cambiar la API pública (`update_anime_controller`) ni el esquema de base de datos.
+
+## Decisions
+
+### 1. Patrón "recolectar todo, luego commitear todo" en lugar de partir en dos transacciones
+
+Se reordena `update_anime_info` en dos fases secuenciales:
+
+- **Fase de recolección** (sin transacción de escritura abierta): `scrape_anime_info(include_episodes=False)`, lectura de `get_max_episode_number` vía una conexión de solo lectura corta (`engine.connect()`), `await asyncio.sleep(1.5)`, y `scrape_new_episodes` con el `last_ep_number` obtenido.
+- **Fase de escritura** (una única `engine.begin()`): `update_anime_fields`, `insert_dummy_anime`/`insert_anime_relation` por relacionado, `insert_new_episodes` — todo con los datos ya recolectados, sin I/O externo dentro del bloque.
+
+**Alternativa considerada**: partir en dos transacciones de escritura (una antes del scrape de episodios, otra después). Se descarta porque rompe la atomicidad global — un fallo en la segunda transacción dejaría la primera ya confirmada, violando el requirement existente de `database-access` sobre operaciones de varias escrituras.
+
+### 2. Lectura de `last_ep_number` fuera de la transacción de escritura
+
+`get_max_episode_number` es una lectura de `episodes`, independiente de las escrituras sobre `animes`/`anime_relations`. Se ejecuta con `engine.connect()` (patrón ya usado en `update_anime_controller`, línea 159), no dentro de `engine.begin()`.
+
+**Alternativa considerada**: mantenerla dentro de la transacción de escritura, tal como está hoy. Se descarta porque es exactamente la lectura que hoy fuerza a que la transacción siga abierta hasta después del segundo scrape.
+
+### 3. Extraer mapeo puro `AnimeInfo → dict`
+
+Se extraen funciones puras (p. ej. `_anime_fields_from_info(anime_info, current_time)` y `_episode_values(episodes, anime_id, base_url)`) a partir del código inline en `service.py:110-114` y `144-152`. No hacen I/O; son las mismas transformaciones que ya existen, solo nombradas y aisladas.
+
+**Alternativa considerada**: dejar el mapeo inline como está. Se descarta porque impide testear la lógica de transformación sin levantar scraping o base de datos — codegraph ya señala que ni `upsert_scraped_anime` ni las funciones de `scraper.py` tienen tests que las cubran.
+
+## Risks / Trade-offs
+
+- **[Riesgo]** Si la transacción de escritura falla después de haber scrapeado (p. ej. la base no responde en ese momento), el resultado del scraping se descarta y hay que volver a scrapear en el próximo intento. → **Mitigación**: aceptable — no hay escritura parcial (se preserva atomicidad), y el flujo se dispara por acción del usuario o de un job que puede reintentar; es el mismo costo de "volver a intentar" que ya existe hoy si la transacción actual fallara en su paso final.
+- **[Riesgo]** La latencia total de `update_anime_info` no baja (sigue siendo secuencial: red → red → DB), solo baja el tiempo que la conexión de escritura permanece abierta. → **Mitigación**: ninguna necesaria; ese es el objetivo del cambio, no una regresión.
+- **[Riesgo]** Extraer funciones de mapeo puede introducir un bug sutil de transcripción si no se testean. → **Mitigación**: `tasks.md` debe incluir tests unitarios para los helpers extraídos.
+
+## Migration Plan
+
+Cambio de código puro, sin migración de datos ni de esquema. Se despliega como cualquier otro cambio de `service.py`. Rollback: revertir el commit: no hay estado intermedio persistido que dependa del nuevo orden.
+
+## Open Questions
+
+Ninguna pendiente. El propósito de `await asyncio.sleep(1.5)` está confirmado: es una pausa deliberada para respetar el rate limit del sitio scrapeado entre el primer y el segundo scrape (no está documentado en el historial de git, pero se confirmó con el autor). El rediseño lo reubica sin cambiar su posición relativa (justo antes de `scrape_new_episodes`), preservando su propósito.

--- a/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/proposal.md
+++ b/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`update_anime_info` (`backend/src/packages/animes/service.py`) abre una transacción de escritura (`engine.begin()`) y, dentro de ella, hace un `asyncio.sleep(1.5)` y una segunda llamada de scraping HTTP (`scrape_new_episodes`) antes de escribir los episodios nuevos. Eso retiene una conexión de Postgres del pool durante I/O externo lento y no determinístico, lo que agota el pool bajo carga concurrente y alarga locks sin necesidad. `add_new_anime` no tiene este problema (scrapea antes de abrir la transacción), pero ambos flujos entrelazan el mapeo `AnimeInfo → dict` de columnas inline con las llamadas a `repository`, dificultando testear cada capa por separado.
+
+## What Changes
+
+- Reordenar `update_anime_info` para que todo el I/O externo (los dos scrapes y el `sleep` de cortesía entre ellos) ocurra **antes** de abrir la transacción de escritura. La lectura de `get_max_episode_number` pasa a hacerse con una conexión de solo lectura corta (`engine.connect()`), independiente de la transacción de escritura.
+- Consolidar todas las escrituras (`update_anime_fields`, `insert_dummy_anime`, `insert_anime_relation`, `insert_new_episodes`) en una única transacción corta al final, sin I/O de red ni `sleep` dentro de su alcance.
+- Extraer el mapeo `AnimeInfo` (scraper) → `dict` de columnas de `animes`/`episodes` a funciones puras, testeables sin mockear red ni base de datos.
+- Sin cambios en `scraper.py` ni `repository.py`: la separación es de orquestación en `service.py`.
+
+## Capabilities
+
+### New Capabilities
+
+(ninguna)
+
+### Modified Capabilities
+
+- `database-access`: nuevo requirement — una unidad de trabajo (transacción) no permanece abierta durante I/O externo ajeno a la base de datos (llamadas de red, esperas artificiales). El requirement existente de atomicidad de escrituras múltiples se preserva sin cambios.
+
+## Impact
+
+- `backend/src/packages/animes/service.py`: reescritura de `update_anime_info` (orden de operaciones) y extracción de helpers de mapeo puro.
+- `openspec/specs/database-access/spec.md`: nuevo requirement sobre alcance de la conexión frente a I/O externo.
+- Sin cambios de API pública, de schema de base de datos, ni de comportamiento observable para el usuario final (mismo resultado final, misma atomicidad de escritura).

--- a/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/specs/database-access/spec.md
+++ b/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/specs/database-access/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: La conexión no permanece abierta durante I/O externo ajeno a la base de datos
+
+Una vez abierta una transacción, SHALL NOT permanecer abierta mientras se espera una respuesta de un sistema externo (por ejemplo, una petición HTTP a un sitio de terceros) ni mientras transcurre una espera deliberada (por ejemplo, una pausa para respetar un rate limit). Todo dato que dependa de un sistema externo SHALL obtenerse antes de abrir la transacción que lo persiste.
+
+#### Scenario: El resultado de una llamada externa se obtiene antes de abrir la transacción
+
+- **WHEN** una operación necesita datos obtenidos de un sistema externo para completar sus escrituras
+- **THEN** esos datos se obtienen antes de abrir la transacción de escritura
+- **AND** la transacción, una vez abierta, no espera ninguna respuesta externa
+
+#### Scenario: Una espera deliberada ocurre fuera de cualquier transacción abierta
+
+- **WHEN** una operación necesita una pausa deliberada (por ejemplo, para respetar el rate limit de un sitio externo)
+- **THEN** esa pausa transcurre sin ninguna transacción abierta
+- **AND** ninguna conexión del pool queda retenida durante esa pausa
+
+#### Scenario: La transacción abierta solo contiene operaciones de base de datos
+
+- **WHEN** se inspecciona el código dentro de un bloque de transacción
+- **THEN** todas las llamadas dentro de ese bloque son operaciones de lectura o escritura sobre la base de datos
+- **AND** ninguna es una llamada de red externa ni una espera artificial

--- a/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/tasks.md
+++ b/openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/tasks.md
@@ -1,0 +1,24 @@
+## 1. Extraer helpers de mapeo puro
+
+- [x] 1.1 Crear `_anime_fields_from_info(anime_info, current_time)` en `service.py` que devuelva el dict de columnas de `animes` (`title`, `description`, `poster`, `type`, `is_finished`, `week_day`, `last_scraped_at`) a partir de un `AnimeInfo`, sin I/O.
+- [x] 1.2 Crear `_episode_values(episodes, anime_id, base_url)` en `service.py` que devuelva la lista de dicts usada por `insert_episodes`/`insert_new_episodes`, sin I/O.
+- [x] 1.3 Reemplazar el código inline equivalente en `add_new_anime` y `update_anime_info` por llamadas a estos helpers, sin cambiar el comportamiento resultante.
+
+## 2. Reordenar `update_anime_info`
+
+- [x] 2.1 Mover la lectura de `get_max_episode_number` fuera de la transacción de escritura, usando `engine.connect()` (conexión de solo lectura corta, mismo patrón que `update_anime_controller`).
+- [x] 2.2 Mover `await asyncio.sleep(1.5)` y `scrape_new_episodes` antes de abrir la transacción de escritura, preservando su orden relativo (sleep primero, luego el scrape, para seguir respetando el rate limit del sitio).
+- [x] 2.3 Consolidar `update_anime_fields`, el loop de `insert_dummy_anime`/`insert_anime_relation`, e `insert_new_episodes` dentro de una única `engine.begin()` al final, usando los datos ya recolectados en la fase previa.
+- [x] 2.4 Revisar el diff final y confirmar que ninguna llamada de red ni `sleep` queda dentro del bloque `engine.begin()`.
+
+## 3. Tests
+
+- [x] 3.1 Actualizar `test_update_anime_info_keeps_previous_fields_on_mid_transaction_failure` (`backend/tests/test_animes_atomicity.py`) para mockear también `scrape_new_episodes` — con el nuevo orden se invoca incondicionalmente antes de la transacción, ya no queda "protegida" por la falla inyectada en `insert_dummy_anime`.
+- [x] 3.2 En ese mismo test (o en un fixture compartido), mockear `asyncio.sleep` para que el test no pague la espera real de 1.5s.
+- [x] 3.3 Agregar tests unitarios para `_anime_fields_from_info` y `_episode_values` que no requieran red ni base de datos.
+- [x] 3.4 Agregar un test que confirme el orden de operaciones: `scrape_anime_info` y `scrape_new_episodes` se invocan antes de que se abra cualquier conexión de escritura (por ejemplo, instrumentando los mocks para registrar el orden de llamadas).
+- [x] 3.5 Correr la suite de tests de `backend` y confirmar que pasan, incluyendo `test_animes_atomicity.py`.
+
+## 4. Cierre del change
+
+- [x] 4.1 Correr `openspec validate --changes decouple-anime-scrape-persist` y confirmar que sigue pasando tras la implementación.

--- a/openspec/specs/database-access/spec.md
+++ b/openspec/specs/database-access/spec.md
@@ -117,3 +117,25 @@ El backend SHALL verificar la conectividad con la base durante su arranque y SHA
 
 - **WHEN** el backend se detiene ordenadamente
 - **THEN** las conexiones que mantenía quedan liberadas
+
+### Requirement: La conexión no permanece abierta durante I/O externo ajeno a la base de datos
+
+Una vez abierta una transacción, SHALL NOT permanecer abierta mientras se espera una respuesta de un sistema externo (por ejemplo, una petición HTTP a un sitio de terceros) ni mientras transcurre una espera deliberada (por ejemplo, una pausa para respetar un rate limit). Todo dato que dependa de un sistema externo SHALL obtenerse antes de abrir la transacción que lo persiste.
+
+#### Scenario: El resultado de una llamada externa se obtiene antes de abrir la transacción
+
+- **WHEN** una operación necesita datos obtenidos de un sistema externo para completar sus escrituras
+- **THEN** esos datos se obtienen antes de abrir la transacción de escritura
+- **AND** la transacción, una vez abierta, no espera ninguna respuesta externa
+
+#### Scenario: Una espera deliberada ocurre fuera de cualquier transacción abierta
+
+- **WHEN** una operación necesita una pausa deliberada (por ejemplo, para respetar el rate limit de un sitio externo)
+- **THEN** esa pausa transcurre sin ninguna transacción abierta
+- **AND** ninguna conexión del pool queda retenida durante esa pausa
+
+#### Scenario: La transacción abierta solo contiene operaciones de base de datos
+
+- **WHEN** se inspecciona el código dentro de un bloque de transacción
+- **THEN** todas las llamadas dentro de ese bloque son operaciones de lectura o escritura sobre la base de datos
+- **AND** ninguna es una llamada de red externa ni una espera artificial


### PR DESCRIPTION
## Why

`update_anime_info` retenía una transacción de escritura de Postgres abierta mientras hacía scraping HTTP externo y una pausa de rate limit (`asyncio.sleep(1.5)`), agotando el pool de conexiones bajo carga concurrente.

## What Changes

- Se extraen los helpers puros `_anime_fields_from_info` y `_episode_values` (sin I/O) a partir del mapeo `AnimeInfo → dict` que antes vivía inline.
- `update_anime_info` se reordena: ambos scrapes y el sleep de rate limit ocurren antes de abrir la transacción; la lectura de `last_ep_number` usa una conexión de solo lectura corta; todas las escrituras quedan en una única transacción final, sin I/O externo dentro.
- Se agrega un requirement nuevo a la capability `database-access` (spec-driven): una transacción no puede permanecer abierta durante I/O externo.

## Impact

- `backend/src/packages/animes/service.py`
- Tests: `test_animes_atomicity.py` actualizado, `test_animes_scrape_persist_order.py` nuevo
- Sin cambios de API pública, schema de base de datos ni comportamiento observable (misma atomicidad de escritura)

## Testing

- `pytest tests/` → 19 passed en 6.24s

Implementado vía OpenSpec (`openspec/changes/archive/2026-08-18-decouple-anime-scrape-persist/`).